### PR TITLE
Added CentOS 8 DevOps tool server build configuration for Vagrant.

### DIFF
--- a/shared/linux-universal/install_terraform.sh
+++ b/shared/linux-universal/install_terraform.sh
@@ -21,7 +21,7 @@ echo "Terraform binaries use the zip utility for archiving. Installing zip and u
 # Download and unpack Terraform
 echo "Downloading and unpacking the Terraform binaries to a common PATH ..."
 sudo wget https://releases.hashicorp.com/terraform/${tf_version}/terraform_${tf_version}_linux_amd64.zip -P /opt/terraform &>/dev/null
-sudo unzip -o /opt/terraform/terraform_${tf_version}_linux_amd64.zip -d /opt/terraform
+sudo unzip -o /opt/terraform/terraform_${tf_version}_linux_amd64.zip -d /opt/terraform &>/dev/null
 sudo mv /opt/terraform/terraform /usr/local/bin/terraform
 
 #Clean up

--- a/vagrant/virtualbox/centos8/devops-tool-server/Vagrantfile
+++ b/vagrant/virtualbox/centos8/devops-tool-server/Vagrantfile
@@ -1,0 +1,37 @@
+# CentOS 7 - DevOps Tools Server
+
+# Script for Java JDK 8 (OpenJDK), Git, Docker, and Ansible installation
+$tools = <<-SCRIPT
+containerio=$(curl -s https://download.docker.com/linux/centos/7/x86_64/stable/Packages/ | cut -d ">" -f2 | cut -d "<" -f1 | grep containerd.io | tail -1)
+echo "Installing dependencies for the DevOps tools ..."
+dnf install -y yum-utils epel-release wget &>/dev/null
+echo "Installing a compatible version of the containerd-io package as a prerequisite for Docker ..."
+dnf install -y \
+    https://download.docker.com/linux/centos/7/x86_64/stable/Packages/${containerio} &>/dev/null
+echo "Adding Docker repo for the pending installation ..."
+yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo &>/dev/null
+echo "Installing Java, Git, Docker and Ansible (this process may take a few minutes to complete) ..."
+dnf install -y java-1.8.0-openjdk-devel docker-ce ansible git &>/dev/null
+echo "Starting and enabling Docker ..."
+systemctl start docker && systemctl enable docker &>/dev/null
+echo "Running Hello World container to validate Docker installation ..."
+docker run hello-world
+usermod -aG docker vagrant
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.define "centos8-devops-tools-server"
+  config.vm.hostname = "centos8-dev"
+  config.vm.box = "centos/8"
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+
+# Install the prescribed tools (Java JDK 8 (OpenJDK), Git, Maven, Ansible, Terraform, Docker, Kubectl for remote Kubernetes cluster access)
+  config.vm.provision "shell", inline: $tools
+  config.vm.provision :shell, path: "../../../../shared/linux-universal/install_maven.sh"
+  config.vm.provision :shell, path: "../../../../shared/linux-universal/install_terraform.sh"
+  config.vm.provision :shell, path: "../../../../shared/linux-universal/install_kubectl.sh"
+end


### PR DESCRIPTION
Features:

- CentOS 8 now available as an option for the DevOps tools server build set (Vagrant)

Validation:
(Output logs including the command run and the time stats)
[centos8-devops-tool-server.vagrant-build.log](https://github.com/antoinne-williams/velos/files/4532905/centos8-devops-tool-server.vagrant-build.log)
