### PR TITLE
Added base builds for CentOS 7 and 8 and Ubuntu 18 (Vagrant)

### DIFF
--- a/vagrant/virtualbox/centos7/base/Vagrantfile
+++ b/vagrant/virtualbox/centos7/base/Vagrantfile
@@ -1,0 +1,12 @@
+# CentOS 7 - Base Server
+
+Vagrant.configure("2") do |config|
+  config.vm.define "centos7-base-server"
+  config.vm.hostname = "centos7-base"
+  config.vm.box = "centos/7"
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+end

--- a/vagrant/virtualbox/centos8/base/Vagrantfile
+++ b/vagrant/virtualbox/centos8/base/Vagrantfile
@@ -1,0 +1,12 @@
+# CentOS 8 - Base Server
+
+Vagrant.configure("2") do |config|
+  config.vm.define "centos8-base-server"
+  config.vm.hostname = "centos8-base"
+  config.vm.box = "centos/8"
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+end

--- a/vagrant/virtualbox/centos8/devops-tool-server/Vagrantfile
+++ b/vagrant/virtualbox/centos8/devops-tool-server/Vagrantfile
@@ -1,4 +1,4 @@
-# CentOS 7 - DevOps Tools Server
+# CentOS 8 - DevOps Tools Server
 
 # Script for Java JDK 8 (OpenJDK), Git, Docker, and Ansible installation
 $tools = <<-SCRIPT

--- a/vagrant/virtualbox/ubuntu18/base/Vagrantfile
+++ b/vagrant/virtualbox/ubuntu18/base/Vagrantfile
@@ -1,0 +1,12 @@
+# Ubuntu 18 - Base Server
+
+Vagrant.configure("2") do |config|
+  config.vm.define "ubuntu18-base-server"
+  config.vm.hostname = "ubuntu18-base"
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--audio", "none"]
+    vb.memory = 4096
+    vb.cpus = 2
+  end
+end


### PR DESCRIPTION
Features:

- CentOS 7/8 and Ubuntu 18 base builds available via Vagrant

Validation:
(Log output including command run and time stats)
[centos7-base-server.vagrant-build.log](https://github.com/antoinne-williams/velos/files/4535689/centos7-base-server.vagrant-build.log)
[centos8-base-server.vagrant-build.log](https://github.com/antoinne-williams/velos/files/4535690/centos8-base-server.vagrant-build.log)
[ubuntu18-base-server.vagrant-build.log](https://github.com/antoinne-williams/velos/files/4535691/ubuntu18-base-server.vagrant-build.log)
